### PR TITLE
Fix `test_make_transparent()` AssertionError when running `pytest`

### DIFF
--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -1,7 +1,71 @@
 """Initial tests of basic functionality."""
 
-import subprocess, filecmp
+from datetime import datetime
+from os.path import getsize, getmtime
 from pathlib import Path
+import filecmp, json, subprocess
+
+from PIL import Image, ImageChops
+
+
+TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# --- Helper used in the tests. ---
+
+def readable_file_size(in_bytes: int) -> str:
+    """Convert bytes to human-readable KB, MB, or GB
+
+    Args:
+        in_bytes: input bytes
+
+    Returns:
+        str
+    """
+    for unit in ["B", "KB", "MB", "GB"]:
+        if in_bytes < 1024:
+            break
+        in_bytes /= 1024
+    return f"{in_bytes:.2f} {unit}"
+
+
+def are_images_equal(path1: Path | str, path2: Path | str) -> bool:
+    """Check if two image files are visually equal pixel-wise
+
+    Args:
+        path1: image1 file path
+        path2: image2 file path
+
+    Returns:
+        bool: True - visually equal, False - not visually equal
+    """
+    size1 = getsize(path1)
+    m_ts1 = datetime.fromtimestamp(getmtime(path1)).strftime(TS_FORMAT)
+    with Image.open(path1) as img1:
+        meta1 = {
+            "file_size": readable_file_size(size1),
+            "file_ts": m_ts1,
+            "format": img1.format,
+            "size": img1.size,
+            "mode": img1.mode,
+            "info": img1.info,
+        }
+        data1 = img1.convert("RGB")
+    size2 = getsize(path2)
+    m_ts2 = datetime.fromtimestamp(getmtime(path2)).strftime(TS_FORMAT)
+    with Image.open(path2) as img2:
+        meta2 = {
+            "file_size": readable_file_size(size2),
+            "file_ts": m_ts2,
+            "format": img2.format,
+            "size": img2.size,
+            "mode": img2.mode,
+            "info": img2.info,
+        }
+        data2 = img2.convert("RGB")
+    print(f"Meta of {path1}:\n{json.dumps(meta1, indent=2)}")
+    print(f"Meta of {path2}:\n{json.dumps(meta2, indent=2)}")
+    return ImageChops.difference(data1, data2).getbbox() is None
+
 
 # --- Tests for correct usage. ---
 
@@ -91,14 +155,7 @@ def test_make_transparent():
     # assert filecmp.cmp(path_modified, path_reference)
     # JL 2025-08-12: The metadata or compression can make PNG files binary different
     # even if they look the same. Fix: use Pillow library to compare pixel equality.
-    from PIL import Image, ImageChops
-
-    def images_are_equal(img1_path, img2_path):
-        img1 = Image.open(img1_path).convert("RGB")
-        img2 = Image.open(img2_path).convert("RGB")
-        return ImageChops.difference(img1, img2).getbbox() is None
-
-    assert images_are_equal(path_modified, path_reference)
+    assert are_images_equal(path_modified, path_reference) is True
 
 
 # --- Tests for incorrect usage. ---

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -89,9 +89,8 @@ def test_make_transparent():
 
     subprocess.run(cmd_parts)
     # assert filecmp.cmp(path_modified, path_reference)
-    # JL 2025-08-12: Fix: the metadata or compression can make PNG files binary
-    # different even if they look the same. We should use Pillow library to do pixel
-    # equality comparison.
+    # JL 2025-08-12: The metadata or compression can make PNG files binary different
+    # even if they look the same. Fix: use Pillow library to compare pixel equality.
     from PIL import Image, ImageChops
 
     def images_are_equal(img1_path, img2_path):

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -88,7 +88,18 @@ def test_make_transparent():
     cmd_parts = cmd.split()
 
     subprocess.run(cmd_parts)
-    assert filecmp.cmp(path_modified, path_reference)
+    # assert filecmp.cmp(path_modified, path_reference)
+    # JL 2025-08-12: Fix: the metadata or compression can make PNG files binary
+    # different even if they look the same. We should use Pillow library to do pixel
+    # equality comparison.
+    from PIL import Image, ImageChops
+
+    def images_are_equal(img1_path, img2_path):
+        img1 = Image.open(img1_path).convert("RGB")
+        img2 = Image.open(img2_path).convert("RGB")
+        return ImageChops.difference(img1, img2).getbbox() is None
+
+    return images_are_equal(path_modified, path_reference)
 
 
 # --- Tests for incorrect usage. ---

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -99,7 +99,7 @@ def test_make_transparent():
         img2 = Image.open(img2_path).convert("RGB")
         return ImageChops.difference(img1, img2).getbbox() is None
 
-    return images_are_equal(path_modified, path_reference)
+    assert images_are_equal(path_modified, path_reference)
 
 
 # --- Tests for incorrect usage. ---


### PR DESCRIPTION
1. Fix `test_make_transparent()` AssertionError when running `pytest`. Run `pytest` after the fix:
```
pytest
...
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
...
configfile: pyproject.toml
plugins: cov-6.2.1
collected 9 items                                                                                                                                           

tests/test_basic_functionality.py .........                                                                                                           [100%]

...== 9 passed in 0.93s ==...
```
2. Ran a single test case in test file, `test_basic_functionality.py`
```
pytest -sv tests/test_basic_functionality.py -k test_make_transparent
...
tests/test_basic_functionality.py::test_make_transparent New image saved at tests/source_images/gh_screenshot_bordered.png
Meta of tests/source_images/gh_screenshot_bordered.png:
{
  "file_size": "34.49 KB",
  "file_ts": "2025-08-13 17:47:08",
  "format": "PNG",
  "size": [
    866,
    387
  ],
  "mode": "RGBA",
  "info": {}
}
Meta of tests/reference_images/gh_screenshot_transparent.png:
{
  "file_size": "38.56 KB",
  "file_ts": "2025-08-12 12:00:31",
  "format": "PNG",
  "size": [
    866,
    387
  ],
  "mode": "RGBA",
  "info": {}
}
PASSED
...
```
3. Fixes #3 